### PR TITLE
Downgrade codecov CI action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,4 +45,4 @@ jobs:
         run: make cover
 
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
## Why

- Codecov action v4 doesn't support upload result without token